### PR TITLE
Add link to public release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 
 - [Interactive (Manual)](https://www.terraform.io/docs/enterprise/install/installer.html)
 - [Automated](https://www.terraform.io/docs/enterprise/install/automating-the-installer.html)
+- [Release Notes](https://github.com/hashicorp/terraform-enterprise-release-notes)
 
 ## Sentinel (Policy / Governance)
 


### PR DESCRIPTION
TFE release notes are now public, adding a link to that repository.